### PR TITLE
Remove start time/close time from delete and get workflow execution

### DIFF
--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -971,8 +971,6 @@ func (s *TaskSerializer) visibilityDeleteTaskToProto(
 		Version:               deleteVisibilityTask.Version,
 		TaskId:                deleteVisibilityTask.TaskID,
 		VisibilityTime:        timestamppb.New(deleteVisibilityTask.VisibilityTimestamp),
-		StartTime:             timestamppb.New(deleteVisibilityTask.StartTime),
-		CloseTime:             timestamppb.New(deleteVisibilityTask.CloseTime),
 		CloseVisibilityTaskId: deleteVisibilityTask.CloseExecutionVisibilityTaskID,
 	}
 }
@@ -989,8 +987,6 @@ func (s *TaskSerializer) visibilityDeleteTaskFromProto(
 		VisibilityTimestamp:            deleteVisibilityTask.VisibilityTime.AsTime(),
 		TaskID:                         deleteVisibilityTask.TaskId,
 		Version:                        deleteVisibilityTask.Version,
-		StartTime:                      deleteVisibilityTask.StartTime.AsTime(),
-		CloseTime:                      deleteVisibilityTask.CloseTime.AsTime(),
 		CloseExecutionVisibilityTaskID: deleteVisibilityTask.CloseVisibilityTaskId,
 	}
 }

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -622,7 +622,6 @@ func (s *VisibilityPersistenceSuite) TestDeleteWorkflow() {
 			NamespaceID: testNamespaceUUID,
 			WorkflowID:  row.GetExecution().GetWorkflowId(),
 			RunID:       row.GetExecution().GetRunId(),
-			StartTime:   startTime,
 		})
 		s.Nil(err7)
 	}
@@ -716,7 +715,6 @@ func (s *VisibilityPersistenceSuite) TestGetWorkflowExecution() {
 			&manager.GetWorkflowExecutionRequest{
 				NamespaceID: testNamespaceUUID,
 				RunID:       req.Execution.RunId,
-				StartTime:   startTime,
 			},
 		)
 		s.NoError(err)
@@ -733,7 +731,6 @@ func (s *VisibilityPersistenceSuite) TestGetWorkflowExecution() {
 			&manager.GetWorkflowExecutionRequest{
 				NamespaceID: testNamespaceUUID,
 				RunID:       req.Execution.RunId,
-				CloseTime:   closeTime,
 			},
 		)
 		s.NoError(err)

--- a/common/persistence/visibility/manager/visibility_manager.go
+++ b/common/persistence/visibility/manager/visibility_manager.go
@@ -178,8 +178,6 @@ type (
 		RunID       string
 		WorkflowID  string
 		TaskID      int64
-		StartTime   time.Time // if start time is not empty, delete record from open_execution for cassandra db
-		CloseTime   time.Time // if end time is not empty, delete record from closed_execution for cassandra db
 	}
 
 	// GetWorkflowExecutionRequest is request from GetWorkflowExecution
@@ -188,8 +186,6 @@ type (
 		Namespace   namespace.Name // namespace.Name is not persisted
 		RunID       string
 		WorkflowID  string
-		StartTime   time.Time // if start time is not empty, search record from open_execution for cassandra db
-		CloseTime   time.Time // if end time is not empty, search record from closed_execution for cassandra db
 	}
 
 	// GetWorkflowExecutionResponse is response to GetWorkflowExecution

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -42,7 +42,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.temporal.io/api/temporalproto"
 	"go.temporal.io/server/common/debug"
@@ -1741,7 +1740,6 @@ func (s *ESVisibilitySuite) TestCountGroupByWorkflowExecutions() {
 }
 
 func (s *ESVisibilitySuite) TestGetWorkflowExecution() {
-	now := timestamppb.New(time.Now())
 	s.mockESClient.EXPECT().Get(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index string, docID string) (*elastic.GetResult, error) {
 			s.Equal(testIndex, index)
@@ -1765,7 +1763,6 @@ func (s *ESVisibilitySuite) TestGetWorkflowExecution() {
 		Namespace:   testNamespace,
 		WorkflowID:  testWorkflowID,
 		RunID:       testRunID,
-		CloseTime:   now.AsTime(),
 	}
 	_, err := s.visibilityStore.GetWorkflowExecution(context.Background(), request)
 	s.NoError(err)

--- a/common/persistence/visibility/visibility_manager_test.go
+++ b/common/persistence/visibility/visibility_manager_test.go
@@ -309,7 +309,6 @@ func (s *VisibilityManagerSuite) TestGetWorkflowExecution() {
 		Namespace:   testNamespace,
 		RunID:       testWorkflowExecution.RunId,
 		WorkflowID:  testWorkflowExecution.WorkflowId,
-		CloseTime:   time.Now(),
 	}
 	s.visibilityStore.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(
 		&store.InternalGetWorkflowExecutionResponse{},

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -28,7 +28,6 @@ package deletemanager
 
 import (
 	"context"
-	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 
@@ -175,11 +174,6 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 		return err
 	}
 
-	// These two fields are needed for cassandra standard visibility.
-	// TODO (alex): Remove them when cassandra standard visibility is removed.
-	var startTime time.Time
-	var closeTime time.Time
-
 	if err := m.shardContext.DeleteWorkflowExecution(
 		ctx,
 		definition.WorkflowKey{
@@ -188,8 +182,6 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 			RunID:       we.GetRunId(),
 		},
 		currentBranchToken,
-		startTime,
-		closeTime,
 		ms.GetExecutionInfo().GetCloseVisibilityTaskId(),
 		stage,
 	); err != nil {

--- a/service/history/deletemanager/delete_manager_test.go
+++ b/service/history/deletemanager/delete_manager_test.go
@@ -27,7 +27,6 @@ package deletemanager
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -128,8 +127,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution() {
 			RunID:       tests.RunID,
 		},
 		[]byte{22, 8, 78},
-		time.Time{},
-		time.Time{},
 		closeExecutionVisibilityTaskID,
 		&stage,
 	).Return(nil)
@@ -170,8 +167,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution_Error() 
 			RunID:       tests.RunID,
 		},
 		[]byte{22, 8, 78},
-		time.Time{},
-		time.Time{},
 		closeExecutionVisibilityTaskID,
 		&stage,
 	).Return(serviceerror.NewInternal("test error"))
@@ -211,8 +206,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecution_OpenWorkflow() 
 			RunID:       tests.RunID,
 		},
 		[]byte{22, 8, 78},
-		time.Time{},
-		time.Time{},
 		closeExecutionVisibilityTaskID,
 		&stage,
 	).Return(nil)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1901,8 +1901,6 @@ func (h *Handler) DeleteWorkflowVisibilityRecord(
 		WorkflowID:  request.Execution.GetWorkflowId(),
 		RunID:       request.Execution.GetRunId(),
 		TaskID:      math.MaxInt64,
-		StartTime:   request.GetWorkflowStartTime().AsTime(),
-		CloseTime:   request.GetWorkflowCloseTime().AsTime(),
 	})
 	if err != nil {
 		return nil, h.convertError(err)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -115,7 +115,7 @@ type (
 		GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error)
 		// DeleteWorkflowExecution add task to delete visibility, current workflow execution, and deletes workflow execution.
 		// If branchToken != nil, then delete history also, otherwise leave history.
-		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime time.Time, closeTime time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error
+		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error
 
 		UnloadForOwnershipLost()
 	}

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -931,8 +931,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	ctx context.Context,
 	key definition.WorkflowKey,
 	branchToken []byte,
-	startTime time.Time,
-	closeTime time.Time,
 	closeVisibilityTaskId int64,
 	stage *tasks.DeleteWorkflowExecutionStage,
 ) (retErr error) {
@@ -1009,8 +1007,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 							// TaskID is set by addTasks
 							WorkflowKey:                    key,
 							VisibilityTimestamp:            s.timeSource.Now(),
-							StartTime:                      startTime,
-							CloseTime:                      closeTime,
 							CloseExecutionVisibilityTaskID: closeVisibilityTaskId,
 						},
 					},

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -180,17 +180,17 @@ func (mr *MockContextMockRecorder) CurrentVectorClock() *gomock.Call {
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error {
+func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, closeExecutionVisibilityTaskID, stage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, closeExecutionVisibilityTaskID, stage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, closeExecutionVisibilityTaskID, stage)
 }
 
 // GenerateTaskID mocks base method.
@@ -868,17 +868,17 @@ func (mr *MockControllableContextMockRecorder) CurrentVectorClock() *gomock.Call
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockControllableContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error {
+func (m *MockControllableContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, closeExecutionVisibilityTaskID, stage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockControllableContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage interface{}) *gomock.Call {
+func (mr *MockControllableContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, closeExecutionVisibilityTaskID, stage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, closeExecutionVisibilityTaskID, stage)
 }
 
 // FinishStop mocks base method.

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -221,8 +221,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -247,8 +245,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_Continue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -262,8 +258,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_Continue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -276,8 +270,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_Continue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -301,8 +293,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_ErrorAndContinue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -315,8 +305,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_ErrorAndContinue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -329,8 +317,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_ErrorAndContinue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -342,8 +328,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_ErrorAndContinue_Success() {
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -366,8 +350,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_DeleteVisibilityTaskNotificti
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)
@@ -382,8 +364,6 @@ func (s *contextSuite) TestDeleteWorkflowExecution_DeleteVisibilityTaskNotificti
 		context.Background(),
 		workflowKey,
 		branchToken,
-		time.Time{},
-		time.Time{},
 		0,
 		&stage,
 	)

--- a/service/history/tasks/delete_visibility_task.go
+++ b/service/history/tasks/delete_visibility_task.go
@@ -40,10 +40,6 @@ type (
 		TaskID                         int64
 		Version                        int64
 		CloseExecutionVisibilityTaskID int64
-		// These two fields are needed for cassandra standard visibility.
-		// TODO (alex): Remove them when cassandra standard visibility is removed.
-		StartTime time.Time
-		CloseTime time.Time
 	}
 )
 

--- a/service/history/visibility_queue_task_executor.go
+++ b/service/history/visibility_queue_task_executor.go
@@ -318,8 +318,6 @@ func (t *visibilityQueueTaskExecutor) processDeleteExecution(
 		WorkflowID:  task.WorkflowID,
 		RunID:       task.RunID,
 		TaskID:      task.TaskID,
-		StartTime:   task.StartTime,
-		CloseTime:   task.CloseTime,
 	}
 	if t.ensureCloseBeforeDelete() {
 		// If visibility delete task is executed before visibility close task then visibility close task

--- a/service/history/workflow/relocatable_attributes_fetcher.go
+++ b/service/history/workflow/relocatable_attributes_fetcher.go
@@ -99,7 +99,6 @@ func (f *relocatableAttributesFetcher) Fetch(
 			Namespace:   mutableState.GetNamespaceEntry().Name(),
 			RunID:       executionState.GetRunId(),
 			WorkflowID:  executionInfo.GetWorkflowId(),
-			CloseTime:   executionInfo.CloseTime.AsTime(),
 		},
 	)
 	if err != nil {

--- a/service/history/workflow/relocatable_attributes_fetcher_test.go
+++ b/service/history/workflow/relocatable_attributes_fetcher_test.go
@@ -117,7 +117,6 @@ func TestRelocatableAttributesFetcher_Fetch(t *testing.T) {
 					Namespace:   namespaceEntry.Name(),
 					RunID:       tests.RunID,
 					WorkflowID:  tests.WorkflowID,
-					CloseTime:   closeTime,
 				}).Return(&manager.GetWorkflowExecutionResponse{
 					Execution: &workflow.WorkflowExecutionInfo{
 						Memo:             persistenceAttributes.Memo,

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -191,10 +191,8 @@ func (a *Activities) deleteWorkflowExecutionFromVisibility(
 
 	a.logger.Info("Deleting workflow execution from visibility.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 	_, err := a.historyClient.DeleteWorkflowVisibilityRecord(ctx, &historyservice.DeleteWorkflowVisibilityRecordRequest{
-		NamespaceId:       namespaceID.String(),
-		Execution:         execution.GetExecution(),
-		WorkflowStartTime: execution.GetStartTime(),
-		WorkflowCloseTime: execution.GetCloseTime(),
+		NamespaceId: namespaceID.String(),
+		Execution:   execution.GetExecution(),
 	})
 	switch err.(type) {
 	case nil:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove `StartTime`/`CloseTime` from delete and get workflow execution in visibility API.

## Why?
<!-- Tell your future self why have you made these changes -->
These parameters were only necessary for Cassandra visibility.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.
